### PR TITLE
Add Experience Cloud branding loader and starter CSS resource

### DIFF
--- a/docs/community-portal-update.md
+++ b/docs/community-portal-update.md
@@ -1,0 +1,45 @@
+# Experience Cloud community portal update plan
+
+## What’s included in this repo now
+
+This repo did not include Experience Builder bundles or theme overrides for the community portal. To make the portal match `fpinsights.fptransitions.com`, I added a lightweight branding loader component and a static CSS resource you can tailor to the desired look and feel.
+
+## New code added
+
+### 1) Global branding loader component
+
+Place the `communityBrandingLoader` component on your Experience Builder Theme Layout or on specific pages. It loads a global CSS resource into the portal.
+
+**Files**
+
+- `force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.js`
+- `force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.html`
+- `force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.js-meta.xml`
+
+### 2) CSS static resource
+
+Update the tokens and classes in `fpCommunityBranding.css` to mirror the palette/typography from the target site.
+
+**Files**
+
+- `force-app/main/default/staticresources/fpCommunityBranding.css`
+- `force-app/main/default/staticresources/fpCommunityBranding.resource-meta.xml`
+
+## How to deploy and update the portal
+
+1. **Deploy the new assets** to your org (via `sfdx force:source:deploy -p force-app/main/default`).
+2. **Open Experience Builder** for your community.
+3. **Add the `communityBrandingLoader` component** to the Theme Layout (best) or to every page so the CSS resource loads globally.
+4. **Adjust Branding Set** values (logo, colors, fonts) in Experience Builder to match the target site.
+5. **Update page content** using the `.fp-hero`, `.fp-card-grid`, and `.fp-card` utility classes from the static resource for sections that should visually match the target.
+6. **Publish** the site once the styling matches your expectations.
+
+## Optional: bring Experience Builder metadata into source control
+
+If you want the entire portal definition in this repo, retrieve the Experience Cloud bundle:
+
+```bash
+sfdx force:source:retrieve -m "ExperienceBundle:Your_Site_Name"
+```
+
+This will add Experience Builder pages, theme layout, and branding metadata under `force-app/main/default/experiences/` and `force-app/main/default/brandingSets/` for future updates.

--- a/force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.html
+++ b/force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.html
@@ -1,0 +1,6 @@
+<template>
+  <!--
+    This component only loads a global CSS resource for Experience Cloud branding.
+    Place it in the Theme Layout or on individual pages in Experience Builder.
+  -->
+</template>

--- a/force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.js
+++ b/force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.js
@@ -1,0 +1,19 @@
+import { LightningElement } from "lwc";
+import { loadStyle } from "lightning/platformResourceLoader";
+import brandingStyles from "@salesforce/resourceUrl/fpCommunityBranding";
+
+export default class CommunityBrandingLoader extends LightningElement {
+  stylesLoaded = false;
+
+  renderedCallback() {
+    if (this.stylesLoaded) {
+      return;
+    }
+
+    this.stylesLoaded = true;
+    loadStyle(this, brandingStyles).catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error("Failed to load community branding styles.", error);
+    });
+  }
+}

--- a/force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.js-meta.xml
+++ b/force-app/main/default/lwc/communityBrandingLoader/communityBrandingLoader.js-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>59.0</apiVersion>
+  <isExposed>true</isExposed>
+  <targets>
+    <target>lightningCommunity__Page</target>
+    <target>lightningCommunity__ThemeLayout</target>
+  </targets>
+</LightningComponentBundle>

--- a/force-app/main/default/staticresources/fpCommunityBranding.css
+++ b/force-app/main/default/staticresources/fpCommunityBranding.css
@@ -1,0 +1,90 @@
+/*
+  Community branding overrides for FP Transitions Experience Cloud portal.
+  Update the color tokens and font stacks to match fpinsights.fptransitions.com.
+*/
+:root {
+  --fp-brand-navy: #0b1f2a;
+  --fp-brand-teal: #0b6b75;
+  --fp-brand-sand: #f4efe9;
+  --fp-brand-gold: #c19a5b;
+  --fp-font-sans: 'Inter', 'Salesforce Sans', Arial, sans-serif;
+  --fp-font-serif: 'Merriweather', Georgia, serif;
+}
+
+body,
+.comm-page-custom,
+.comm-theme-layout {
+  font-family: var(--fp-font-sans);
+  color: var(--fp-brand-navy);
+  background-color: var(--fp-brand-sand);
+}
+
+a,
+.comm-navigation__link,
+.slds-text-link {
+  color: var(--fp-brand-teal);
+}
+
+a:hover,
+.comm-navigation__link:hover,
+.slds-text-link:hover {
+  color: var(--fp-brand-navy);
+}
+
+.slds-button_brand,
+.comm-button--primary {
+  background-color: var(--fp-brand-teal);
+  border-color: var(--fp-brand-teal);
+  color: #fff;
+}
+
+.slds-button_brand:hover,
+.comm-button--primary:hover {
+  background-color: var(--fp-brand-navy);
+  border-color: var(--fp-brand-navy);
+}
+
+.slds-button_neutral,
+.comm-button--secondary {
+  border-color: var(--fp-brand-navy);
+  color: var(--fp-brand-navy);
+}
+
+.slds-button_neutral:hover,
+.comm-button--secondary:hover {
+  background-color: rgba(11, 31, 42, 0.08);
+}
+
+/* Hero/section utilities for key landing sections. */
+.fp-hero {
+  background: linear-gradient(135deg, var(--fp-brand-navy), var(--fp-brand-teal));
+  color: #fff;
+  padding: 4rem 2rem;
+  border-radius: 1.5rem;
+}
+
+.fp-hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.fp-hero__title {
+  font-family: var(--fp-font-serif);
+  font-size: clamp(2rem, 3vw, 3rem);
+  margin-top: 0.75rem;
+}
+
+.fp-card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.fp-card {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 32px rgba(11, 31, 42, 0.08);
+}

--- a/force-app/main/default/staticresources/fpCommunityBranding.resource-meta.xml
+++ b/force-app/main/default/staticresources/fpCommunityBranding.resource-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+  <cacheControl>Public</cacheControl>
+  <contentType>text/css</contentType>
+</StaticResource>


### PR DESCRIPTION
### Motivation
- The community portal lacked Experience Builder theme overrides to match the visual design of `fpinsights.fptransitions.com`. 
- Provide a minimal, maintainable way to inject global branding styles across the Experience Cloud site without importing full ExperienceBundle metadata. 

### Description
- Add a lightweight LWC `communityBrandingLoader` that loads a global static CSS resource and is exposed to `lightningCommunity__Page` and `lightningCommunity__ThemeLayout` via `communityBrandingLoader.js`, `communityBrandingLoader.html`, and `communityBrandingLoader.js-meta.xml`. 
- Add a starter CSS static resource named `fpCommunityBranding.css` with design tokens and utility classes such as `.fp-hero`, `.fp-card-grid`, and `.fp-card` plus the corresponding `fpCommunityBranding.resource-meta.xml`. 
- Add documentation `docs/community-portal-update.md` explaining deployment steps and how to apply the component in Experience Builder and how to retrieve ExperienceBundle metadata if desired. 

### Testing
- Ran `prettier --write` which completed successfully. 
- Ran `eslint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696fc0abbe00832d8f6474217cac137b)